### PR TITLE
net5 and use of record

### DIFF
--- a/Code/DataStuctures/Face.cs
+++ b/Code/DataStuctures/Face.cs
@@ -1,3 +1,5 @@
+using System.Numerics;
+
 namespace qem
 {
     public class Face
@@ -27,7 +29,7 @@ namespace qem
 
         public override string ToString()
         {
-            return $"V1: {V1.Vector} V2: {V2.Vector} V3: {V3.Vector}";
+            return $"V1: {V1.Vector3} V2: {V2.Vector3} V3: {V3.Vector3}";
         }
 
         public bool Equals2(Vertex v1, Vertex v2, Vertex v3)
@@ -50,10 +52,10 @@ namespace qem
         //    return base.GetHashCode();
         //}
 
-        public Vector Normal()
+        public Vector3 Normal()
         {
-            Vector e1 = V2.Vector - V1.Vector;
-            Vector e2 = V3.Vector - V1.Vector;
+            Vector3 e1 = V2.Vector3 - V1.Vector3;
+            Vector3 e2 = V3.Vector3 - V1.Vector3;
             return e1.Cross(e2).Normalize();
         }
     }

--- a/Code/DataStuctures/Matrix.cs
+++ b/Code/DataStuctures/Matrix.cs
@@ -2,29 +2,29 @@ namespace qem
 {
     public struct Matrix
     {
-        public double x00, x01, x02, x03;
-        public double x10, x11, x12, x13;
-        public double x20, x21, x22, x23;
-        public double x30, x31, x32, x33;
+        public float x00, x01, x02, x03;
+        public float x10, x11, x12, x13;
+        public float x20, x21, x22, x23;
+        public float x30, x31, x32, x33;
 
         #region Ctor
         public Matrix(
-        double x00,
-        double x01,
-        double x02,
-        double x03,
-        double x10,
-        double x11,
-        double x12,
-        double x13,
-        double x20,
-        double x21,
-        double x22,
-        double x23,
-        double x30,
-        double x31,
-        double x32,
-        double x33
+        float x00,
+        float x01,
+        float x02,
+        float x03,
+        float x10,
+        float x11,
+        float x12,
+        float x13,
+        float x20,
+        float x21,
+        float x22,
+        float x23,
+        float x30,
+        float x31,
+        float x32,
+        float x33
         )
         {
             this.x00 = x00;
@@ -49,7 +49,7 @@ namespace qem
 
     public static class MatrixEx
     {
-        public static double QuadricError(this Matrix a, Vector v)
+        public static float QuadricError(this Matrix a, Vector v)
         {
             return (v.X * a.x00 * v.X + v.Y * a.x10 * v.X + v.Z * a.x20 * v.X + a.x30 * v.X +
                v.X * a.x01 * v.Y + v.Y * a.x11 * v.Y + v.Z * a.x21 * v.Y + a.x31 * v.Y +
@@ -101,7 +101,7 @@ namespace qem
             return m;
         }
 
-        public static double Determinant(this Matrix a)
+        public static float Determinant(this Matrix a)
         {
             return (a.x00 * a.x11 * a.x22 * a.x33 - a.x00 * a.x11 * a.x23 * a.x32 +
                 a.x00 * a.x12 * a.x23 * a.x31 - a.x00 * a.x12 * a.x21 * a.x33 +

--- a/Code/DataStuctures/Matrix.cs
+++ b/Code/DataStuctures/Matrix.cs
@@ -1,3 +1,5 @@
+using System.Numerics;
+
 namespace qem
 {
     public struct Matrix
@@ -49,7 +51,7 @@ namespace qem
 
     public static class MatrixEx
     {
-        public static float QuadricError(this Matrix a, Vector v)
+        public static float QuadricError(this Matrix a, Vector3 v)
         {
             return (v.X * a.x00 * v.X + v.Y * a.x10 * v.X + v.Z * a.x20 * v.X + a.x30 * v.X +
                v.X * a.x01 * v.Y + v.Y * a.x11 * v.Y + v.Z * a.x21 * v.Y + a.x31 * v.Y +
@@ -57,7 +59,7 @@ namespace qem
                v.X * a.x03 + v.Y * a.x13 + v.Z * a.x23 + a.x33);
         }
 
-        public static Vector QuadricVector(this Matrix a)
+        public static Vector3 QuadricVector(this Matrix a)
         {
             var m = new Matrix(
                 a.x00, a.x01, a.x02, a.x03,
@@ -65,7 +67,7 @@ namespace qem
                 a.x20, a.x21, a.x22, a.x23,
                 0, 0, 0, 1);
 
-            return m.Inverse().MulPosition(new Vector());
+            return m.Inverse().MulPosition(new Vector3());
         }
 
         public static Matrix Add(this Matrix a, Matrix b)
@@ -117,9 +119,9 @@ namespace qem
                 a.x03 * a.x12 * a.x20 * a.x31 + a.x03 * a.x12 * a.x21 * a.x30);
         }
 
-        public static Vector MulPosition(this Matrix a, Vector b)
+        public static Vector3 MulPosition(this Matrix a, Vector3 b)
         {
-            return new Vector(
+            return new Vector3(
                 a.x00 * b.X + a.x01 * b.Y + a.x02 * b.Z + a.x03,
                 a.x10 * b.X + a.x11 * b.Y + a.x12 * b.Z + a.x13,
                 a.x20 * b.X + a.x21 * b.Y + a.x22 * b.Z + a.x23);

--- a/Code/DataStuctures/Pair.cs
+++ b/Code/DataStuctures/Pair.cs
@@ -69,7 +69,7 @@ namespace qem
             return A.Quadric.Add(B.Quadric);
         }
 
-        public struct Key
+        public record Key
         {
             public Vector A, B;
             public Key(Vector a, Vector b)

--- a/Code/DataStuctures/Pair.cs
+++ b/Code/DataStuctures/Pair.cs
@@ -7,7 +7,7 @@ namespace qem
     public class Pair
     {
         public Vertex A, B;
-        public double CachedError;
+        public float CachedError;
         public bool Removed;
 
         public Pair(Vertex a, Vertex b)
@@ -29,7 +29,7 @@ namespace qem
             if (Math.Abs(q.Determinant()) > 1e-3)
             {
                 var v = q.QuadricVector();
-                if (!double.IsNaN(v.X) && !double.IsNaN(v.Y) && !double.IsNaN(v.Z))
+                if (!float.IsNaN(v.X) && !float.IsNaN(v.Y) && !float.IsNaN(v.Z))
                     return v;
             }
 
@@ -55,7 +55,7 @@ namespace qem
             return bestV;
         }
 
-        public double Error()
+        public float Error()
         {
             if (CachedError < 0)
             {

--- a/Code/DataStuctures/Pair.cs
+++ b/Code/DataStuctures/Pair.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 
 namespace qem
 {
@@ -12,7 +13,7 @@ namespace qem
 
         public Pair(Vertex a, Vertex b)
         {
-            if (a.Vector < b.Vector)
+            if (a.Vector3.Less(b.Vector3))
             {
                 (a, b) = (b, a);
             }
@@ -22,7 +23,7 @@ namespace qem
             Removed = false;
         }
 
-        public Vector Vector()
+        public Vector3 Vector()
         {
             var q = Quadric();
 
@@ -36,15 +37,15 @@ namespace qem
             //cannot compute best vector with matrix 
             // look for vest along edge
             int n = 32;
-            var a = A.Vector;
-            var b = B.Vector;
+            var a = A.Vector3;
+            var b = B.Vector3;
             var bestE = -1d;
-            var bestV = new Vector();
+            var bestV = new Vector3();
 
             for (int i = 0; i < n; i++)
             {
                 int frac = i * (1 / n);
-                var v = qem.Vector.Lerp(a, b, frac);
+                var v = Vector3.Lerp(a, b, frac);
                 var e = A.Quadric.QuadricError(v);
                 if (bestE < 0 || e < bestE)
                 {
@@ -71,8 +72,8 @@ namespace qem
 
         public record Key
         {
-            public Vector A, B;
-            public Key(Vector a, Vector b)
+            public Vector3 A, B;
+            public Key(Vector3 a, Vector3 b)
             {
                 A = a;
                 B = b;
@@ -80,11 +81,11 @@ namespace qem
 
             public static Key Make(Vertex a, Vertex b)
             {
-                if (a.Vector < b.Vector)
+                if (a.Vector3.Less(b.Vector3))
                 {
-                    return new Key(a.Vector, b.Vector);
+                    return new Key(a.Vector3, b.Vector3);
                 }
-                return new Key(b.Vector, a.Vector);
+                return new Key(b.Vector3, a.Vector3);
             }
         }
     }

--- a/Code/DataStuctures/Triangle.cs
+++ b/Code/DataStuctures/Triangle.cs
@@ -1,10 +1,12 @@
+using System.Numerics;
+
 namespace qem
 {
-    public struct Triangle
+    public record Triangle
     {
-        public Vector v1, v2, v3;
+        public Vector3 v1, v2, v3;
 
-        public Triangle(Vector v1, Vector v2, Vector v3)
+        public Triangle(Vector3 v1, Vector3 v2, Vector3 v3)
         {
             this.v1 = v1;
             this.v2 = v2;
@@ -31,7 +33,7 @@ namespace qem
             );
         }
 
-        public Vector Normal()
+        public Vector3 Normal()
         {
             var e1 = v2 - v1;
             var e2 = v3 - v2;

--- a/Code/DataStuctures/Vector.cs
+++ b/Code/DataStuctures/Vector.cs
@@ -1,108 +1,35 @@
 using System;
+using System.Numerics;
+
 namespace qem
 {
-    public struct Vector
-    {
-        public float X, Y, Z;
-
-        public Vector(float x, float y, float z)
-        {
-            X = x;
-            Y = y;
-            Z = z;
-        }
-
-        public float Length => (float)(Math.Sqrt(X * X + Y * Y + Z * Z));
-        public static Vector operator +(Vector a, Vector b) => new Vector(a.X + b.X, a.Y + b.Y, a.Z + b.Z);
-        public static Vector operator -(Vector a, Vector b) => new Vector(a.X - b.X, a.Y - b.Y, a.Z - b.Z);
-        public static Vector operator *(Vector a, float f) => new Vector(a.X * f, a.Y * f, a.Z * f);
-        public static Vector operator /(Vector a, float f) => new Vector(a.X / f, a.Y / f, a.Z / f);
-
-
-        public static bool operator ==(Vector a, Vector b) => Equals(a, b);
-        public static bool operator !=(Vector a, Vector b) => !Equals(a, b);
-        public static bool operator >(Vector a, Vector b) => a.Less(b);
-        public static bool operator <(Vector a, Vector b) => !a.Less(b);
-
-        public static Vector Lerp(Vector a, Vector b, float frac)
-        {
-            var x = Lerp(a.X, b.X, frac);
-            var y = Lerp(a.Y, b.Y, frac);
-            var z = Lerp(a.Z, b.Z, frac);
-            return new Vector(x, y, z);
-        }
-
-        public static float Lerp(float firstFloat, float secondFloat, float by)
-        {
-            return firstFloat * (1 - by) + secondFloat * by;
-        }
-
-        public override bool Equals(object obj)
-        {
-            var other = (Vector)obj;
-            return nearlyEqual(other.X, X) && nearlyEqual(other.Y, Y) && nearlyEqual(other.Z, Z);
-        }
-
-        public override int GetHashCode()
-        {
-            return string.Format("{0}_{1}_{2}", X, Y, Z).GetHashCode();
-        }
-
-        private bool Less(Vector b)
-        {
-            if (X != b.X)
-            {
-                return X < b.X;
-            }
-            if (Y != b.Y)
-            {
-                return Y < b.Y;
-            }
-            return Z < b.Z;
-        }
-
-        public static bool nearlyEqual(float a, float b)
-        {
-            var epsilon = float.Epsilon;
-            var absA = Math.Abs(a);
-            var absB = Math.Abs(b);
-            var diff = Math.Abs(a - b);
-
-            if (a == b)
-            { // shortcut, handles infinities
-                return true;
-            }
-            else if (a == 0 || b == 0 || diff < float.MinValue)
-            {
-                // a or b is zero or both are extremely close to it
-                // relative error is less meaningful here
-                return diff < (epsilon * float.MaxValue);
-            }
-            else
-            { // use relative error
-                return diff / (absA + absB) < epsilon;
-            }
-        }
-
-        public override string ToString()
-        {
-            return $"({X};{Y};{Z})";
-        }
-
-        public Vector Normalize() => this * (1f / Length);
-    }
-
+    
     public static class VectorEx
     {
-        public static Vector Cross(this Vector a, Vector b)
+        public static bool Less(this Vector3 a, Vector3 b)
         {
-            var x = a.Y * b.Z - a.Z * b.Y;
-            var y = a.Z * b.X - a.X * b.Z;
-            var z = a.X * b.Y - a.Y * b.X;
-
-            return new Vector(x, y, z);
+            if (a.X != b.X)
+            {
+                return a.X < b.X;
+            }
+            if (a.Y != b.Y)
+            {
+                return a.Y < b.Y;
+            }
+            return a.Z < b.Z;
+        }
+        public static Vector3 Cross(this Vector3 a, Vector3 b)
+        {
+            return Vector3.Cross(a, b);
+        }
+        public static Vector3 Normalize(this Vector3 a)
+        {
+            return Vector3.Normalize(a);
+        }
+        public static float Dot(this Vector3 a, Vector3 b)
+        {
+            return Vector3.Dot(a,b);
         }
 
-        public static float Dot(this Vector a, Vector b) => a.X * b.X + a.Y * b.Y + a.Z * b.Z;
     }
 }

--- a/Code/DataStuctures/Vector.cs
+++ b/Code/DataStuctures/Vector.cs
@@ -3,20 +3,20 @@ namespace qem
 {
     public struct Vector
     {
-        public double X, Y, Z;
+        public float X, Y, Z;
 
-        public Vector(double x, double y, double z)
+        public Vector(float x, float y, float z)
         {
             X = x;
             Y = y;
             Z = z;
         }
 
-        public double Length => Convert.ToDouble(Math.Sqrt(X * X + Y * Y + Z * Z));
+        public float Length => (float)(Math.Sqrt(X * X + Y * Y + Z * Z));
         public static Vector operator +(Vector a, Vector b) => new Vector(a.X + b.X, a.Y + b.Y, a.Z + b.Z);
         public static Vector operator -(Vector a, Vector b) => new Vector(a.X - b.X, a.Y - b.Y, a.Z - b.Z);
-        public static Vector operator *(Vector a, double f) => new Vector(a.X * f, a.Y * f, a.Z * f);
-        public static Vector operator /(Vector a, double f) => new Vector(a.X / f, a.Y / f, a.Z / f);
+        public static Vector operator *(Vector a, float f) => new Vector(a.X * f, a.Y * f, a.Z * f);
+        public static Vector operator /(Vector a, float f) => new Vector(a.X / f, a.Y / f, a.Z / f);
 
 
         public static bool operator ==(Vector a, Vector b) => Equals(a, b);
@@ -24,7 +24,7 @@ namespace qem
         public static bool operator >(Vector a, Vector b) => a.Less(b);
         public static bool operator <(Vector a, Vector b) => !a.Less(b);
 
-        public static Vector Lerp(Vector a, Vector b, double frac)
+        public static Vector Lerp(Vector a, Vector b, float frac)
         {
             var x = Lerp(a.X, b.X, frac);
             var y = Lerp(a.Y, b.Y, frac);
@@ -32,7 +32,7 @@ namespace qem
             return new Vector(x, y, z);
         }
 
-        public static double Lerp(double firstFloat, double secondFloat, double by)
+        public static float Lerp(float firstFloat, float secondFloat, float by)
         {
             return firstFloat * (1 - by) + secondFloat * by;
         }
@@ -61,9 +61,9 @@ namespace qem
             return Z < b.Z;
         }
 
-        public static bool nearlyEqual(double a, double b)
+        public static bool nearlyEqual(float a, float b)
         {
-            var epsilon = double.Epsilon;
+            var epsilon = float.Epsilon;
             var absA = Math.Abs(a);
             var absB = Math.Abs(b);
             var diff = Math.Abs(a - b);
@@ -72,11 +72,11 @@ namespace qem
             { // shortcut, handles infinities
                 return true;
             }
-            else if (a == 0 || b == 0 || diff < double.MinValue)
+            else if (a == 0 || b == 0 || diff < float.MinValue)
             {
                 // a or b is zero or both are extremely close to it
                 // relative error is less meaningful here
-                return diff < (epsilon * double.MaxValue);
+                return diff < (epsilon * float.MaxValue);
             }
             else
             { // use relative error
@@ -89,7 +89,7 @@ namespace qem
             return $"({X};{Y};{Z})";
         }
 
-        public Vector Normalize() => this * (1d / Length);
+        public Vector Normalize() => this * (1f / Length);
     }
 
     public static class VectorEx
@@ -103,6 +103,6 @@ namespace qem
             return new Vector(x, y, z);
         }
 
-        public static double Dot(this Vector a, Vector b) => a.X * b.X + a.Y * b.Y + a.Z * b.Z;
+        public static float Dot(this Vector a, Vector b) => a.X * b.X + a.Y * b.Y + a.Z * b.Z;
     }
 }

--- a/Code/DataStuctures/Vertex.cs
+++ b/Code/DataStuctures/Vertex.cs
@@ -1,19 +1,21 @@
+using System.Numerics;
+
 namespace qem
 {
     public class Vertex
     {
-        public Vector Vector;
+        public Vector3 Vector3;
         public Matrix Quadric;
 
-        public Vertex(Vector v)
+        public Vertex(Vector3 v)
         {
-            Vector = v;
+            Vector3 = v;
             Quadric = new Matrix();
         }
 
-        public Vertex(Vector v, Matrix q)
+        public Vertex(Vector3 v, Matrix q)
         {
-            Vector = v;
+            Vector3 = v;
             Quadric = q;
         }
     }

--- a/Code/QEMAlgorithm.cs
+++ b/Code/QEMAlgorithm.cs
@@ -2,12 +2,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 
 namespace qem
 {
     public static class QEMAlgorithm
     {
-        private static void AddVertex(Vector v, Dictionary<Vector, Vertex> dic)
+        private static void AddVertex(Vector3 v, Dictionary<Vector3, Vertex> dic)
         {
             if (!dic.ContainsKey(v))
                 dic.Add(v, new Vertex(v));
@@ -21,7 +22,7 @@ namespace qem
         public static Mesh Simplify(this Mesh originalMesh, int targetCount)
         {
             // gather distinct vertices
-            Dictionary<Vector, Vertex> vectorVertex = new Dictionary<Vector, Vertex>(originalMesh.vertexCount);
+            Dictionary<Vector3, Vertex> vectorVertex = new Dictionary<Vector3, Vertex>(originalMesh.vertexCount);
 
             foreach (Triangle t in originalMesh.tris)
             {
@@ -211,7 +212,7 @@ namespace qem
                 if (vertexPairs.ContainsKey(p.B))
                     vertexPairs.Remove(p.B);
 
-                var seen = new Dictionary<Vector, bool>();
+                var seen = new Dictionary<Vector3, bool>();
 
                 foreach (var q in distintPairs)
                 {
@@ -232,15 +233,15 @@ namespace qem
                         (a, b) = (b, a);
                         // a = v
                     }
-                    if (seen.ContainsKey(b.Vector) && seen[b.Vector])
+                    if (seen.ContainsKey(b.Vector3) && seen[b.Vector3])
                     {
                         //ignore duplicates
                         continue;
                     }
-                    if (!seen.ContainsKey(b.Vector))
-                        seen.Add(b.Vector, true);
+                    if (!seen.ContainsKey(b.Vector3))
+                        seen.Add(b.Vector3, true);
                     else
-                        seen[b.Vector] = true;
+                        seen[b.Vector3] = true;
 
                     var np = new Pair(a, b);
                     np.Error();
@@ -268,7 +269,7 @@ namespace qem
             //create final mesh
             Mesh newMesh = new Mesh
             {
-                tris = finalDistinctFaces.Select(x => new Triangle(x.V1.Vector, x.V2.Vector, x.V3.Vector)).ToArray()
+                tris = finalDistinctFaces.Select(x => new Triangle(x.V1.Vector3, x.V2.Vector3, x.V3.Vector3)).ToArray()
             };
 
             return newMesh;

--- a/Code/QEMAlgorithm.cs
+++ b/Code/QEMAlgorithm.cs
@@ -21,7 +21,7 @@ namespace qem
         public static Mesh Simplify(this Mesh originalMesh, int targetCount)
         {
             // gather distinct vertices
-            Dictionary<Vector, Vertex> vectorVertex = new Dictionary<Vector, Vertex>();
+            Dictionary<Vector, Vertex> vectorVertex = new Dictionary<Vector, Vertex>(originalMesh.vertexCount);
 
             foreach (Triangle t in originalMesh.tris)
             {
@@ -45,7 +45,7 @@ namespace qem
             }
 
             //vertex -> face map
-            Dictionary<Vertex, List<Face>> vertexFaces = new Dictionary<Vertex, List<Face>>();
+            Dictionary<Vertex, List<Face>> vertexFaces = new Dictionary<Vertex, List<Face>>(originalMesh.vertexCount);
             foreach (Triangle t in originalMesh.tris)
             {
                 Vertex v1 = vectorVertex[t.v1];
@@ -61,7 +61,7 @@ namespace qem
 
             System.Diagnostics.Stopwatch sw = System.Diagnostics.Stopwatch.StartNew();
             //gather distinct pairs
-            Dictionary<Pair.Key, Pair> pairs = new Dictionary<Pair.Key, Pair>();
+            Dictionary<Pair.Key, Pair> pairs = new Dictionary<Pair.Key, Pair>(originalMesh.trisCount);
             foreach (Triangle t in originalMesh.tris)
             {
                 Vertex v1 = vectorVertex[t.v1];
@@ -77,7 +77,7 @@ namespace qem
             }
             Console.WriteLine($"total: {sw.ElapsedMilliseconds}");
 
-            Dictionary<Vertex, List<Pair>> vertexPairs = new Dictionary<Vertex, List<Pair>>();
+            Dictionary<Vertex, List<Pair>> vertexPairs = new Dictionary<Vertex, List<Pair>>(originalMesh.vertexCount);
 
             foreach (KeyValuePair<Pair.Key, Pair> p in pairs)
             {

--- a/Code/QEMAlgorithm.cs
+++ b/Code/QEMAlgorithm.cs
@@ -14,7 +14,7 @@ namespace qem
                 dic.Add(v, new Vertex(v));
         }
 
-        private static int CompFloats(double f, double f2)
+        private static int CompFloats(float f, float f2)
         {
             return (f > f2) ? 1 : -1;
         }
@@ -86,7 +86,7 @@ namespace qem
                 vertexPairs.AppendEx(p.Value.B, p.Value);
             }
 
-            var priorityQueue = new SimplePriorityQueue<Pair, double>(CompFloats);
+            var priorityQueue = new SimplePriorityQueue<Pair, float>(CompFloats);
             foreach (KeyValuePair<Pair.Key, Pair> item in pairs)
             {
                 item.Value.Error();

--- a/Code/STLParser.cs
+++ b/Code/STLParser.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Numerics;
 using IxMilia.Stl;
 
 namespace qem
@@ -15,9 +16,9 @@ namespace qem
             );
         }
 
-        private static Vector FromSTLVertex(StlVertex stlVertex)
+        private static Vector3 FromSTLVertex(StlVertex stlVertex)
         {
-            return new Vector(stlVertex.X, stlVertex.Y, stlVertex.Z);
+            return new Vector3(stlVertex.X, stlVertex.Y, stlVertex.Z);
         }
 
         private static StlTriangle ToSTLTriangle(Triangle triangle)
@@ -32,7 +33,7 @@ namespace qem
                 );
         }
 
-        private static StlVertex ToSTLVertex(Vector vector)
+        private static StlVertex ToSTLVertex(Vector3 vector)
         {
             return new StlVertex((float)vector.X, (float)vector.Y, (float)vector.Z);
         }

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "qem": {
       "commandName": "Project",
-      "commandLineArgs": "E:\\Perso\\data\\qem\\ste5.stl E:\\Perso\\data\\qem\\ste_out.stl  -t 2000"
+      "commandLineArgs": "E:\\Perso\\data\\qem\\ste5.stl E:\\Perso\\data\\qem\\ste_out.stl  -q 0,2"
     }
   }
 }

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,7 +1,8 @@
 {
   "profiles": {
     "qem": {
-      "commandName": "Project"
+      "commandName": "Project",
+      "commandLineArgs": "E:\\Perso\\data\\qem\\ste5.stl E:\\Perso\\data\\qem\\ste_out.stl  -t 2000"
     }
   }
 }

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "qem": {
       "commandName": "Project",
-      "commandLineArgs": "E:\\Perso\\data\\qem\\stefull.stl E:\\Perso\\data\\qem\\ste_out.stl  -q 0,2"
+      "commandLineArgs": "E:\\Perso\\data\\qem\\ste5.stl E:\\Perso\\data\\qem\\ste5v2_out.stl  -q 0,3"
     }
   }
 }

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "qem": {
       "commandName": "Project",
-      "commandLineArgs": "E:\\Perso\\data\\qem\\ste5.stl E:\\Perso\\data\\qem\\ste_out.stl  -q 0,2"
+      "commandLineArgs": "E:\\Perso\\data\\qem\\stefull.stl E:\\Perso\\data\\qem\\ste_out.stl  -q 0,2"
     }
   }
 }

--- a/qem.csproj
+++ b/qem.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="IxMilia.Stl" Version="0.1.1" />
-    <PackageReference Include="OptimizedPriorityQueue" Version="4.2.0" />
+    <PackageReference Include="IxMilia.Stl" Version="0.1.2" />
+    <PackageReference Include="OptimizedPriorityQueue" Version="5.1.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/qem.csproj
+++ b/qem.csproj
@@ -12,7 +12,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>qem</ToolCommandName>

--- a/qem.csproj
+++ b/qem.csproj
@@ -1,10 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="IxMilia.Stl" Version="0.1.1" />
     <PackageReference Include="OptimizedPriorityQueue" Version="4.2.0" />


### PR DESCRIPTION
Hi @ShuTheWise,

Thanks a lot for this QEM implementation, and great work. I have tested migration to Net5 and it boosts a lot performance (x10).
Here's what you can do to see boost : 

- change TargetFramework from netcoreapp2.1 to net5.0
- change `Key` from `struct` to `record`

I have made other changes but not mandatory to see performance increase. (changed double to floats, and used System.Numerics for Vectors)